### PR TITLE
fix: pin minio to a specific version

### DIFF
--- a/docs/examples/minio.md
+++ b/docs/examples/minio.md
@@ -18,7 +18,7 @@ file.
 
 ```yaml
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2021-06-17T00-10-46Z
     container_name: qlico-core_minio
     command: server /export
     environment:
@@ -66,7 +66,7 @@ services:
       - "traefik.http.routers.traefik.rule=Host(`traefik.qlico`)"
       - "traefik.http.services.traefik.loadbalancer.server.port=8080"
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2021-06-17T00-10-46Z
     container_name: qlico-core_minio
     command: server /export
     environment:


### PR DESCRIPTION
Because of a breaking change in MinIO it was not possible to run the api
and console on the same port.

See: https://github.com/minio/minio/issues/12660

Fixes #19